### PR TITLE
added feature to display account type on user dashboard

### DIFF
--- a/public/src/client/account/edit.js
+++ b/public/src/client/account/edit.js
@@ -27,7 +27,7 @@ define('forum/account/edit', [
         updateAboutMe();
         handleGroupSort();
     };
-    //updateProfile(): void -> boolean
+    // updateProfile(): void -> boolean
     function updateProfile() {
         const userData = $('form[component="profile/edit/form"]').serializeObject();
         userData.uid = ajaxify.data.uid;

--- a/public/src/client/account/edit.js
+++ b/public/src/client/account/edit.js
@@ -27,7 +27,7 @@ define('forum/account/edit', [
         updateAboutMe();
         handleGroupSort();
     };
-
+    //updateProfile(): void -> boolean
     function updateProfile() {
         const userData = $('form[component="profile/edit/form"]').serializeObject();
         userData.uid = ajaxify.data.uid;

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -322,7 +322,8 @@ define('forum/topic', [
             }
         }
     };
-
+    
+    
     function updateUserBookmark(index) {
         const bookmarkKey = 'topic:' + ajaxify.data.tid + ':bookmark';
         const currentBookmark = ajaxify.data.bookmark || storage.getItem(bookmarkKey);
@@ -357,7 +358,7 @@ define('forum/topic', [
         if (!currentBookmark || parseInt(index, 10) >= parseInt(currentBookmark, 10)) {
             alerts.remove('bookmark');
         }
-    }
+    }   
 
 
     return Topic;

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -322,8 +322,6 @@ define('forum/topic', [
             }
         }
     };
-    
-    
     function updateUserBookmark(index) {
         const bookmarkKey = 'topic:' + ajaxify.data.tid + ':bookmark';
         const currentBookmark = ajaxify.data.bookmark || storage.getItem(bookmarkKey);
@@ -359,7 +357,5 @@ define('forum/topic', [
             alerts.remove('bookmark');
         }
     }   
-
-
     return Topic;
 });

--- a/public/src/client/topic/votes.js
+++ b/public/src/client/topic/votes.js
@@ -9,7 +9,6 @@ define('forum/topic/votes', [
     Votes.addVoteHandler = function () {
         components.get('topic').on('mouseenter', '[data-pid] [component="post/vote-count"]', loadDataAndCreateTooltip);
     };
-
     function loadDataAndCreateTooltip(e) {
         e.stopPropagation();
 

--- a/src/topics/tags.js
+++ b/src/topics/tags.js
@@ -19,7 +19,13 @@ module.exports = function (Topics) {
         if (!Array.isArray(tags) || !tags.length) {
             return;
         }
-
+        var pattern = /^\d{5}$/;
+        if (pattern.test(tags.value)) {
+            tags.isCourse = true;
+        }
+        else {
+            tags.isCourse = false;
+        }
         const cid = await Topics.getTopicField(tid, 'cid');
         const topicSets = tags.map(tag => `tag:${tag}:topics`).concat(
             tags.map(tag => `cid:${cid}:tag:${tag}:topics`)

--- a/src/topics/tags.js
+++ b/src/topics/tags.js
@@ -19,13 +19,6 @@ module.exports = function (Topics) {
         if (!Array.isArray(tags) || !tags.length) {
             return;
         }
-        var pattern = /^\d{5}$/;
-        if (pattern.test(tags.value)) {
-            tags.isCourse = true;
-        }
-        else {
-            tags.isCourse = false;
-        }
         const cid = await Topics.getTopicField(tid, 'cid');
         const topicSets = tags.map(tag => `tag:${tag}:topics`).concat(
             tags.map(tag => `cid:${cid}:tag:${tag}:topics`)

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -4,4 +4,5 @@ export type TagObject = {
   valueEscaped: string;
   color: string;
   bgColor: string;
+  courseColor: string;
 };

--- a/themes/nodebb-theme-persona/library.js
+++ b/themes/nodebb-theme-persona/library.js
@@ -8,6 +8,7 @@ const controllers = require('./lib/controllers');
 
 const library = module.exports;
 
+
 library.init = async function (params) {
     const { router, middleware } = params;
     const routeHelpers = require.main.require('./src/routes/helpers');

--- a/themes/nodebb-theme-persona/templates/account/profile.tpl
+++ b/themes/nodebb-theme-persona/templates/account/profile.tpl
@@ -16,8 +16,11 @@
         <!-- ENDIF banned -->
         <!-- ENDIF isAdminOrGlobalModeratorOrModerator -->
 
+        
+
         <!-- IF selectedGroup.length -->
         <div class="text-center">
+            
         {{{each selectedGroup}}}
         <!-- IF selectedGroup.slug -->
             <a href="{config.relative_path}/groups/{selectedGroup.slug}"><small class="label group-label inline-block" style="color:{selectedGroup.textColor};background-color: {selectedGroup.labelColor};"><!-- IF selectedGroup.icon --><i class="fa {selectedGroup.icon}"></i> <!-- ENDIF selectedGroup.icon -->{selectedGroup.userTitle}</small></a>
@@ -30,6 +33,10 @@
         <!-- IF aboutme -->
         <span component="aboutme" class="text-center aboutme">{aboutmeParsed}</span>
         <!-- ENDIF aboutme -->
+       
+        <div class="account-type text-center">
+            <p class="accounttype">Account Type: {accounttype}</p>
+        </div>
 
         <div class="account-stats">
             <!-- IF !reputation:disabled -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -95,7 +95,7 @@
             <a component="post/downvote" href="#" class="<!-- IF posts.downvoted -->downvoted<!-- ENDIF posts.downvoted -->">
                 <i class="fa fa-chevron-down"></i>
             </a>
-            <!-- ENDIF !downvote:disabled -->
+            <!-- ENpDIF !downvote:disabled -->
         </span>
         <!-- ENDIF !reputation:disabled -->
 

--- a/themes/nodebb-theme-persona/templates/recent.tpl
+++ b/themes/nodebb-theme-persona/templates/recent.tpl
@@ -49,3 +49,5 @@
         <!-- ENDIF config.usePagination -->
     </div>
 </div>
+
+

--- a/themes/nodebb-theme-persona/templates/topic.tpl
+++ b/themes/nodebb-theme-persona/templates/topic.tpl
@@ -6,6 +6,7 @@
 <div class="row">
     <div class="topic <!-- IF widgets.sidebar.length -->col-lg-9 col-sm-12<!-- ELSE -->col-lg-12<!-- ENDIF widgets.sidebar.length -->">
         <div class="topic-header">
+            
             <h1 component="post/header" class="" itemprop="name">
                 <span class="topic-title">
                     <span component="topic/labels">
@@ -85,7 +86,6 @@
         <!-- IF config.enableQuickReply -->
         <!-- IMPORT partials/topic/quickreply.tpl -->
         <!-- ENDIF config.enableQuickReply -->
-
         <!-- IF config.usePagination -->
         <!-- IMPORT partials/paginator.tpl -->
         <!-- ENDIF config.usePagination -->
@@ -99,6 +99,8 @@
     </div>
 </div>
 
+
+
 <div data-widget-area="footer">
     {{{each widgets.footer}}}
     {{widgets.footer.html}}
@@ -110,3 +112,5 @@
     <!-- IMPORT partials/paginator.tpl -->
 </noscript>
 <!-- ENDIF !config.usePagination -->
+
+


### PR DESCRIPTION
resolves [#28](https://github.com/CMU-313/fall23-nodebb-consonants-compadres/issues/28)

The account type (TA, instructor, student) was previously not shown anywhere on the nodebb platform. This pull request contains changes that display the user's account type onto the user dashboard as one of the info fields.