### PR TITLE
hide username on topics for anonymous posts

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
@@ -60,6 +60,7 @@
                 </span>
                 {{{ end }}}
 
+                <!-- Added if-else statement to check whether the post is anonymous. If so, mark the user name as Anonymous. Else show the user name. -->
                 <small class="hidden-xs"><span class="timeago" title="{topics.timestampISO}"></span> &bull; <a href="<!-- IF topics.user.userslug -->{config.relative_path}/user/{topics.user.userslug}<!-- ELSE -->#<!-- ENDIF topics.user.userslug -->">
                 {{{ if topics.isAnonymous }}}
                     Anonymous

--- a/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
@@ -60,7 +60,13 @@
                 </span>
                 {{{ end }}}
 
-                <small class="hidden-xs"><span class="timeago" title="{topics.timestampISO}"></span> &bull; <a href="<!-- IF topics.user.userslug -->{config.relative_path}/user/{topics.user.userslug}<!-- ELSE -->#<!-- ENDIF topics.user.userslug -->">{topics.user.displayname}</a></small>
+                <small class="hidden-xs"><span class="timeago" title="{topics.timestampISO}"></span> &bull; <a href="<!-- IF topics.user.userslug -->{config.relative_path}/user/{topics.user.userslug}<!-- ELSE -->#<!-- ENDIF topics.user.userslug -->">
+                {{{ if topics.isAnonymous }}}
+                    Anonymous
+                {{{ else }}}
+                    {topics.user.displayname}
+                {{{ endif }}}
+                </a></small>
                 <small class="visible-xs-inline">
                     <!-- IF topics.teaser.timestamp -->
                     <span class="timeago" title="{topics.teaser.timestampISO}"></span>


### PR DESCRIPTION
Previously: anonymous posts don't show usernames as anonymous.
With my changes: replaced the username tag for anonymous posts with just the word "Anonymous" in the front end.

resolves #27 