### PR TITLE
added backend and front end to classify post as anonymous

### DIFF
--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -42,6 +42,8 @@ get:
                     nullable: true
                   titleRaw:
                     type: string
+                  isAnonymous:
+                    type: boolean
                   tags:
                     type: array
                     items:

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -42,6 +42,7 @@ get:
                     nullable: true
                   titleRaw:
                     type: string
+                  # Added isAnonymous boolean attribute.
                   isAnonymous:
                     type: boolean
                   tags:

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -33,6 +33,7 @@ module.exports = function (Topics) {
             lastposttime: 0,
             postcount: 0,
             viewcount: 0,
+            // Set is isAnonymous to false as default.
             isAnonymous: false,
         };
 

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -17,6 +17,9 @@ const translator = require('../translator');
 
 module.exports = function (Topics) {
     Topics.create = async function (data) {
+
+        console.assert(data.constructor === Object);
+        
         // This is an internal method, consider using Topics.post instead
         const timestamp = data.timestamp || Date.now();
 

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -33,6 +33,7 @@ module.exports = function (Topics) {
             lastposttime: 0,
             postcount: 0,
             viewcount: 0,
+            isAnonymous: false,
         };
 
         if (Array.isArray(data.tags) && data.tags.length) {

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -91,6 +91,10 @@ function escapeTitle(topicData) {
 }
 
 function modifyTopic(topic, fields) {
+
+    console.assert(topic.constructor === Object);
+    console.assert(typeof fields === 'string');
+
     if (!topic) {
         return;
     }

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -140,6 +140,7 @@ function modifyTopic(topic, fields) {
         });
     }
 
+    // Check if there is a tag called anonymous and set isAnonymous equal to true if there is.
     if (topic.tags){
         topic.isAnonymous = topic.tags.reduce((a, b) => a || b.value == "anonymous", false);
     }

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -139,4 +139,8 @@ function modifyTopic(topic, fields) {
             };
         });
     }
+
+    if (topic.tags){
+        topic.isAnonymous = topic.tags.reduce((a, b) => a || b.value == "anonymous", false);
+    }
 }

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -141,7 +141,7 @@ function modifyTopic(topic, fields) {
     }
 
     // Check if there is a tag called anonymous and set isAnonymous equal to true if there is.
-    if (topic.tags){
-        topic.isAnonymous = topic.tags.reduce((a, b) => a || b.value == "anonymous", false);
+    if (topic.tags) {
+        topic.isAnonymous = topic.tags.reduce((a, b) => a || b.value === 'anonymous', false);
     }
 }

--- a/src/topics/tags.js
+++ b/src/topics/tags.js
@@ -20,6 +20,18 @@ module.exports = function (Topics) {
             return;
         }
 
+        // let regex1 = /\d\d\d\d\d/i;
+        // let regex2 = /\d\d-\d\d\d/i;
+        // for (let i = 0; i < tags.length; i++) {
+        //     const name = tags[i].value;
+        //     if(name.match(regex1) || name.match(regex2) ){
+        //         tags[i].isCourse = true;
+        //     }
+        //     else{
+        //         tags[i].isCourse = false;
+        //     }
+        // }
+
         const cid = await Topics.getTopicField(tid, 'cid');
         const topicSets = tags.map(tag => `tag:${tag}:topics`).concat(
             tags.map(tag => `cid:${cid}:tag:${tag}:topics`)

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -7,6 +7,7 @@
     </div>
 
     <small class="pull-left">
+    <!-- If isAnonymous is true, hide the user name. -->
         <strong>
             {{{if isAnonymous}}}
             Anonymous User

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -8,7 +8,11 @@
 
     <small class="pull-left">
         <strong>
+            {{{if isAnonymous}}}
+            Anonymous User
+            {{{else}}}
             <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+            {{{end}}}
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->


### PR DESCRIPTION
resolves #6 and resolves #16 

I added a boolean attribute to the topic object called isAnonymous to be able to classify whether a topic is anonymous or not. I added the ability for users to make a topic anonymous by putting a tag called "anonymous."

Using this attribute, I changed the front-end UI to say "Anonymous User" rather than the person's username if isAnonymous is set to true.

<img width="1204" alt="Screenshot 2023-10-12 at 5 57 28 PM" src="https://github.com/CMU-313/fall23-nodebb-consonants-compadres/assets/108028617/155af018-c2f8-4cc2-9d8d-c35fd4f0b6d8">

