### PR TITLE
[backend] Add endorsement feature

### DIFF
--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -69,6 +69,8 @@ get:
                           type: number
                         upvotes:
                           type: number
+                        endorse:
+                          type: number
                         downvotes:
                           type: number
                         bookmarks:

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -5,7 +5,7 @@ const plugins = require('../plugins');
 const utils = require('../utils');
 
 const intFields = [
-    'uid', 'pid', 'tid', 'deleted', 'timestamp',
+    'uid', 'pid', 'tid', 'deleted', 'timestamp', 'endorse',
     'upvotes', 'downvotes', 'deleterUid', 'edited',
     'replies', 'bookmarks',
 ];

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -4,6 +4,8 @@ const db = require('../database');
 const plugins = require('../plugins');
 const utils = require('../utils');
 
+
+// indicate the fields for a post object 
 const intFields = [
     'uid', 'pid', 'tid', 'deleted', 'timestamp', 'endorse',
     'upvotes', 'downvotes', 'deleterUid', 'edited',

--- a/src/posts/endorse.js
+++ b/src/posts/endorse.js
@@ -1,17 +1,21 @@
 'use strict';
 
-const meta = require('../meta');
 const db = require('../database');
-const flags = require('../flags');
 const user = require('../user');
-const topics = require('../topics');
-const plugins = require('../plugins');
 const privileges = require('../privileges');
-const translator = require('../translator');
 
 module.exports = function (Posts) {
-
+    /**
+    * Endorse a post.
+    *
+    * @param {number} pid - The ID of the post to endorse.
+    * @param {number} uid - The user ID endorsing the post.
+    * @returns {Promise<Object>} An object representing the endorsement action.
+    */
     Posts.endorse = async function (pid, uid) {
+        console.assert(typeof pid === 'number', 'pid should be a number');
+        console.assert(typeof uid === 'number', 'uid should be a number');
+
         const canEndorse = await privileges.posts.can('posts:endorse', pid, uid);
         if (!canEndorse) {
             throw new Error('[[error:no-privileges]]');
@@ -19,13 +23,39 @@ module.exports = function (Posts) {
         return await toggleEndorse('endorse', pid, uid);
     };
 
+    /**
+    * Toggle an endorsement action.
+    *
+    * @param {string} type - The type of endorsement action (e.g., 'endorse').
+    * @param {number} pid - The ID of the post to toggle endorsement for.
+    * @param {number} uid - The user ID performing the endorsement action.
+    * @returns {Promise<Object>} An object representing the endorsement action.
+    */
     async function toggleEndorse(type, pid, uid) {
+        console.assert(typeof type === 'string', 'type should be a string');
+        console.assert(typeof pid === 'number', 'pid should be a number');
+        console.assert(typeof uid === 'number', 'uid should be a number');
+
         const endorseStatus = await Posts.hasEndorsed(pid, uid);
         await unendorse(pid, uid, type, endorseStatus);
         return await endorse(type, false, pid, uid, endorseStatus);
     }
 
+    /**
+    * Unendorse a post.
+    *
+    * @param {number} pid - The ID of the post to unendorse.
+    * @param {number} uid - The user ID unendorsing the post.
+    * @param {string} type - The type of endorsement action (e.g., 'endorse').
+    * @param {Object} endorseStatus - The endorsement status object.
+    * @returns {Promise<Object|undefined>} An object representing the unendorsement action, or undefined if not applicable.
+    */
     async function unendorse(pid, uid, type, endorseStatus) {
+        console.assert(typeof pid === 'number', 'pid should be a number');
+        console.assert(typeof uid === 'number', 'uid should be a number');
+        console.assert(typeof type === 'string', 'type should be a string');
+        console.assert(typeof endorseStatus === 'object', 'endorseStatus should be an object');
+
         if (!endorseStatus || (!endorseStatus.endorsed)) {
             return;
         }
@@ -33,7 +63,23 @@ module.exports = function (Posts) {
         return await endorse('endorse', true, pid, uid, endorseStatus);
     }
 
+    /**
+    * Perform an endorsement action on a post.
+    *
+    * @param {string} type - The type of endorsement action (e.g., 'endorse').
+    * @param {boolean} unendorse - Whether the action is an unendorsement (true) or endorsement (false).
+    * @param {number} pid - The ID of the post the endorsement action is performed on.
+    * @param {number} uid - The user ID performing the endorsement action.
+    * @param {Object} endorseStatus - The endorsement status object.
+    * @returns {Promise<Object>} An object representing the endorsement action.
+    */
     async function endorse(type, unendorse, pid, uid, endorseStatus) {
+        console.assert(typeof type === 'string', 'type should be a string');
+        console.assert(typeof unendorse === 'boolean', 'unendorse should be a boolean');
+        console.assert(typeof pid === 'number', 'pid should be a number');
+        console.assert(typeof uid === 'number', 'uid should be a number');
+        console.assert(typeof endorseStatus === 'object', 'endorseStatus should be an object');
+
         uid = parseInt(uid, 10);
         if (uid <= 0) {
             throw new Error('[[error:not-logged-in]]');
@@ -51,7 +97,7 @@ module.exports = function (Posts) {
 
         postData.endorse ++;
 
-        return {
+        const returnObject = {
             user: {
                 reputation: newReputation,
             },
@@ -59,15 +105,32 @@ module.exports = function (Posts) {
             post: postData,
             endorse: type === 'endorse' && !unendorse,
         };
+
+        console.assert(typeof returnObject === 'object', 'Return value should be an object');
+
+        return returnObject;
     }
 
+    /**
+    * Check if a user has endorsed a post.
+    *
+    * @param {number} pid - The ID of the post to check for endorsement.
+    * @param {number} uid - The user ID to check for endorsement.
+    * @returns {Promise<{ endorsed: boolean }>} An object indicating whether the user has endorsed the post.
+    */
     Posts.hasEndorsed = async function (pid, uid) {
+        console.assert(typeof pid === 'number', 'pid should be a number');
+        console.assert(typeof uid === 'number', 'uid should be a number');
         if (parseInt(uid, 10) <= 0) {
             return { endorsed: false};
         }
         const hasEndorsed = await db.isMemberOfSets([`pid:${pid}:endorse`], uid);
-        return { endorsed: hasEndorsed[0]};
+
+        const returnObject = {
+            endorsed: hasEndorsed[0],
+        };
+    
+        console.assert(typeof returnObject === 'object', 'Return value should be an object');
+        return returnObject;
     };
-
-
 };

--- a/src/posts/endorse.js
+++ b/src/posts/endorse.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const meta = require('../meta');
+const db = require('../database');
+const flags = require('../flags');
+const user = require('../user');
+const topics = require('../topics');
+const plugins = require('../plugins');
+const privileges = require('../privileges');
+const translator = require('../translator');
+
+module.exports = function (Posts) {
+
+    Posts.endorse = async function (pid, uid) {
+        const canEndorse = await privileges.posts.can('posts:endorse', pid, uid);
+        if (!canEndorse) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        return await toggleEndorse('endorse', pid, uid);
+    };
+
+    async function toggleEndorse(type, pid, uid) {
+        const endorseStatus = await Posts.hasEndorsed(pid, uid);
+        await unendorse(pid, uid, type, endorseStatus);
+        return await endorse(type, false, pid, uid, endorseStatus);
+    }
+
+    async function unendorse(pid, uid, type, endorseStatus) {
+        if (!endorseStatus || (!endorseStatus.endorsed)) {
+            return;
+        }
+
+        return await endorse('endorse', true, pid, uid, endorseStatus);
+    }
+
+    async function endorse(type, unendorse, pid, uid, endorseStatus) {
+        uid = parseInt(uid, 10);
+        if (uid <= 0) {
+            throw new Error('[[error:not-logged-in]]');
+        }
+        const now = Date.now();
+
+        if (type === 'endorse' && !unendorse) {
+            await db.sortedSetAdd(`uid:${uid}:endorse`, now, pid);
+        } else {
+            await db.sortedSetRemove(`uid:${uid}:endorse`, pid);
+        }
+
+        const postData = await Posts.getPostFields(pid, ['pid', 'uid', 'tid']);
+        const newReputation = await user.incrementUserReputationBy(postData.uid, type === 'endorse' ? 1 : 0);
+
+        postData.endorse ++;
+
+        return {
+            user: {
+                reputation: newReputation,
+            },
+            fromuid: uid,
+            post: postData,
+            endorse: type === 'endorse' && !unendorse,
+        };
+    }
+
+    Posts.hasEndorsed = async function (pid, uid) {
+        if (parseInt(uid, 10) <= 0) {
+            return { endorsed: false};
+        }
+        const hasEndorsed = await db.isMemberOfSets([`pid:${pid}:endorse`], uid);
+        return { endorsed: hasEndorsed[0]};
+    };
+
+
+};

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -11,7 +11,21 @@ const categories = require('../categories');
 const utils = require('../utils');
 
 module.exports = function (Posts) {
+
+    /**
+    * Get a summary of posts by their IDs.
+    *
+    * @param {number[]} pids - An array of post IDs.
+    * @param {number} uid - The user ID.
+    * @param {object} options - Options for post summary.
+    * @returns {Promise<Object[]>} An array of post summaries.
+    */
     Posts.getPostSummaryByPids = async function (pids, uid, options) {
+
+        console.assert(Array.isArray(pids), 'pids should be an array of post IDs');
+        console.assert(typeof uid === 'number', 'uid should be a number');
+        console.assert(typeof options === 'object', 'options should be an object');
+
         if (!Array.isArray(pids) || !pids.length) {
             return [];
         }
@@ -58,6 +72,9 @@ module.exports = function (Posts) {
 
         posts = await parsePosts(posts, options);
         const result = await plugins.hooks.fire('filter:post.getPostSummaryByPids', { posts: posts, uid: uid });
+
+        console.assert(Array.isArray(result.posts), 'result should be an object with a "posts" property, which is an array of post summaries');
+        
         return result.posts;
     };
 

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,7 +20,7 @@ module.exports = function (Posts) {
         options.parse = options.hasOwnProperty('parse') ? options.parse : true;
         options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'endorse', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
 
         let posts = await Posts.getPostsFields(pids, fields);
         posts = posts.filter(Boolean);

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -140,7 +140,7 @@ module.exports = function (Posts) {
             throw new Error('[[error:no-user]]');
         }
         let postData = await Posts.getPostsFields(pids, [
-            'pid', 'tid', 'uid', 'content', 'deleted', 'timestamp', 'upvotes', 'downvotes',
+            'pid', 'tid', 'uid', 'content', 'deleted', 'timestamp', 'endorse', 'upvotes', 'downvotes',
         ]);
         postData = postData.filter(p => p.pid && p.uid !== parseInt(toUid, 10));
         pids = postData.map(p => p.pid);

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -134,7 +134,19 @@ module.exports = function (Posts) {
         return await user.isModerator(uid, cids);
     };
 
+
+    /**
+    * Change the owner of posts.
+    *
+    * @param {number[]} pids - An array of post IDs to change ownership.
+    * @param {number} toUid - The new user ID to transfer the posts to.
+    * @returns {Promise<Object[]>} An array of posts after ownership change.
+    */
     Posts.changeOwner = async function (pids, toUid) {
+
+        console.assert(Array.isArray(pids), 'pids should be an array of post IDs');
+        console.assert(typeof toUid === 'number', 'toUid should be a number');
+
         const exists = await user.exists(toUid);
         if (!exists) {
             throw new Error('[[error:no-user]]');
@@ -185,6 +197,8 @@ module.exports = function (Posts) {
             posts: _.cloneDeep(postData),
             toUid: toUid,
         });
+
+        console.assert(Array.isArray(postData));
         return postData;
     };
 


### PR DESCRIPTION
In this commit, I added the backend code for the endorsement feature.  

![Screenshot 2023-10-12 at 5 55 10 PM](https://github.com/CMU-313/fall23-nodebb-consonants-compadres/assets/69522682/1216ce13-bac8-4a4a-ad36-12e98a2fb846)

Users can endorse a post, and the app keeps track of the number of endorsements on a post and shows it. 

I added a number attribute to the post object called "endorse" to keep track of the number of endorsements. In relevant files where a post object is retrieved, I updated the corresponding fields. 

I added a new file called "endorse.js" within src/post/ folder. In this file, I added the endorsement function so that users can endorse a post (when the user has not endorsed the post before), and the number of endorsements goes up by 1. 

resolves #35 