### PR TITLE
added static analysis tool - standardJS

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -10,6 +10,7 @@
     },
     "main": "app.js",
     "scripts": {
+        "standardJS": "standard && node my-tests.js",
         "start": "npx tsc && node loader.js",
         "lint": "npx tsc && eslint --cache ./nodebb .",
         "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
@@ -146,6 +147,7 @@
         "zxcvbn": "4.4.2"
     },
     "devDependencies": {
+        "standard": "*",
         "@apidevtools/swagger-parser": "^10.1.0",
         "@commitlint/cli": "17.3.0",
         "@commitlint/config-angular": "17.3.0",


### PR DESCRIPTION
I installed and used the StandardJS static analysis tool. 
Installation Evidence: 
<img width="697" alt="Screenshot 2023-10-27 at 7 23 03 AM" src="https://github.com/CMU-313/fall23-nodebb-consonants-compadres/assets/69522682/c2c9444a-6216-4545-ba8d-cbc238b67c30">

Terminal Output Evidence: 
Command:
<img width="934" alt="Screenshot 2023-10-27 at 7 31 06 AM" src="https://github.com/CMU-313/fall23-nodebb-consonants-compadres/assets/69522682/929e281f-ded9-4243-9598-0fdfb66bfa5c">

Output File: 
[analysis_tool_output.txt](https://github.com/CMU-313/fall23-nodebb-consonants-compadres/files/13188391/analysis_tool_output.txt)

Terminal Output:
<img width="1101" alt="Screenshot 2023-10-27 at 7 24 41 AM" src="https://github.com/CMU-313/fall23-nodebb-consonants-compadres/assets/69522682/df4a1c2b-2fe4-4910-b9f5-4dc87f888046">
